### PR TITLE
feat(trades): improve trade markers display and fix commission calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ volumes
 mongodb.key
 */skills
 mcp.json
+skills-lock.json

--- a/src/app/(dashboard)/trades/details/[positionId]/page.tsx
+++ b/src/app/(dashboard)/trades/details/[positionId]/page.tsx
@@ -38,6 +38,7 @@ export default function TradeDetails() {
     coin,
     avgPrice = "",
     avgClosePrice = "",
+    positionSide = "",
   } = data || {};
   const formattedSymbol = transformSymbol(symbol);
 
@@ -97,6 +98,7 @@ export default function TradeDetails() {
               updateTime={updateTime as string}
               avgClosePrice={avgClosePrice}
               avgPrice={avgPrice}
+              positionSide={positionSide}
             />
             <TradeNotebook tradeId={_id} coin={coin as Coin} />
           </CardContent>

--- a/src/features/trades/components/trade-chart.tsx
+++ b/src/features/trades/components/trade-chart.tsx
@@ -37,6 +37,7 @@ interface TradeChartProps {
   updateTime: string;
   avgPrice: string;
   avgClosePrice: string;
+  positionSide: string;
   coin: Coin;
 }
 
@@ -67,6 +68,7 @@ export function TradeChart({
   updateTime,
   avgPrice,
   avgClosePrice,
+  positionSide,
 }: TradeChartProps) {
   const { selectedAccount, tradeChartTimeframe, setTradeChartTimeframe } =
     useUserConfigStore();
@@ -179,23 +181,25 @@ export function TradeChart({
     const markerOpenTime = findBarTime(openTime, chartSeriesData);
     const markerUpdateTime = findBarTime(updateTime, chartSeriesData);
 
+    const isLong = positionSide === "LONG";
+
     // open
     markers.push({
       time: markerOpenTime,
-      position: "belowBar",
+      position: isLong ? "belowBar" : "aboveBar",
       color: "#2196F3",
-      shape: "arrowUp",
-      text: `Buy @ ${avgPrice}`,
+      shape: isLong ? "arrowUp" : "arrowDown",
+      text: `Entry @ ${avgPrice}`,
       price: Number(avgPrice),
     });
 
     // close
     markers.push({
       time: markerUpdateTime,
-      position: "aboveBar",
+      position: isLong ? "aboveBar" : "belowBar",
       color: "#e91e63",
-      shape: "arrowDown",
-      text: `Sell @ ${avgClosePrice}`,
+      shape: isLong ? "arrowDown" : "arrowUp",
+      text: `Close @ ${avgClosePrice}`,
       price: Number(avgClosePrice),
     });
 

--- a/src/features/trades/components/trade-info.tsx
+++ b/src/features/trades/components/trade-info.tsx
@@ -128,7 +128,9 @@ export function TradeInfo({
       <InfoRow
         label={t("side")}
         value={positionSide === "LONG" ? t("long") : t("short")}
-        valueClassName={positionSide === "LONG" ? "text-green-500" : "text-red-500"}
+        valueClassName={
+          positionSide === "LONG" ? "text-green-500" : "text-red-500"
+        }
       />
 
       <InfoRow label={t("avg_entry_price")} value={`${avgPrice} ${coin}`} />
@@ -150,7 +152,7 @@ export function TradeInfo({
         label={t("position_commission")}
         value={
           <Profit
-            amount={Number(positionCommission)}
+            amount={-Number(positionCommission)}
             decimals={4}
             coin={coin}
           />


### PR DESCRIPTION
- Add positionSide prop to TradeChart for directional marker display
- Show entry/close markers with appropriate arrows based on long/short position
- Fix position commission display by negating the value
- Add skills-lock.json to .gitignore