### PR TITLE
feat(dashboard): improve day-profits mobile UI and remove trailing em…

### DIFF
--- a/src/features/dashboard/components/day-profits-cell.tsx
+++ b/src/features/dashboard/components/day-profits-cell.tsx
@@ -30,20 +30,20 @@ export function DayProfitsCell({
   return (
     <div
       onClick={amount !== null ? onClick : undefined}
-      className={`min-h-24 border border-gray-200 dark:border-gray-700 rounded-lg flex flex-col  text-end  p-1 md:px-2 ${getCellClassName()}`}
+      className={`min-h-20 md:min-h-30 border border-gray-200 dark:border-gray-700 rounded-lg flex flex-col  text-end  p-1 md:px-2 ${getCellClassName()}`}
     >
       {date !== null && (
         <>
-          <div className="text-xs sm:text-sm  font-medium mb-0.5 sm:mb-1">
+          <div className="text-xs md:text-sm  font-medium mb-0.5 sm:mb-1">
             {date}
           </div>
 
           {amount !== null && (
             <>
               <div
-                className={`text-[8px] sm:text-[10px] lg:text-[1rem] font-bold leading-tight`}
+                className={`text-[9px]  md:text-base lg:text-xl font-bold leading-tight`}
               >
-                {formatDecimal(amount)} {coin}
+                {formatDecimal(amount)}{" "}
               </div>
               <div className="text-[10px] sm:text-xs  leading-tight">
                 <span className="hidden sm:inline">{trades} trades</span>

--- a/src/features/dashboard/components/day-profits-chart.tsx
+++ b/src/features/dashboard/components/day-profits-chart.tsx
@@ -104,10 +104,10 @@ export function DayProfitsChart({
         height={data.length > 10 ? 60 : 30}
       />
       <YAxis
-        width={60}
+        width={45}
         domain={["auto", (dataMax: number) => dataMax * 1.15]}
         tickFormatter={(value) => formatDecimal(Number(value), 0)}
-        tick={{ fontSize: 11 }}
+        tick={{ fontSize: 10 }}
       />
       <Tooltip
         cursor={{
@@ -149,7 +149,7 @@ export function DayProfitsChart({
           </Select>
         </CardAction>
       </CardHeader>
-      <CardContent className="h-[420px] outline-0!">
+      <CardContent className="h-[420px] outline-0! px-2">
         {data.length === 0 ? (
           <div className="flex items-center justify-center h-full">
             <span className="text-muted-foreground">

--- a/src/features/dashboard/components/day-profits.tsx
+++ b/src/features/dashboard/components/day-profits.tsx
@@ -67,7 +67,7 @@ export function DayProfits() {
 
   return (
     <Card className="col-span-2 gap-3">
-      <CardHeader>
+      <CardHeader className="px-2 md:px-6">
         <CardTitle>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-1">
@@ -107,7 +107,7 @@ export function DayProfits() {
           </Badge>
         </CardAction>
       </CardHeader>
-      <CardContent className="overflow-hidden">
+      <CardContent className="overflow-hidden px-2 md:px-6">
         <div className="relative w-full overflow-auto">
           {isLoading && (
             <div className="absolute inset-0 flex items-center justify-center bg-black/50">
@@ -116,7 +116,7 @@ export function DayProfits() {
           )}
 
           <div className="grid grid-cols-7 md:grid-cols-8 gap-3">
-            <div className="grid grid-cols-7 col-span-7 gap-1">
+            <div className="grid grid-cols-7 col-span-7 gap-0.5 md:gap-1">
               {daysOfWeekKeys.map((day) => (
                 <div
                   key={day}

--- a/src/features/dashboard/hooks/useDayProfits.ts
+++ b/src/features/dashboard/hooks/useDayProfits.ts
@@ -233,13 +233,26 @@ export const useDayProfitsData = ({
       current.setDate(current.getDate() + 1);
     }
 
-    return calendarData;
+    // Remove trailing empty weeks (weeks where all cells have date === null)
+    let lastValidIndex = calendarData.length - 1;
+    while (lastValidIndex >= 0) {
+      const weekStartIndex = Math.floor(lastValidIndex / 7) * 7;
+      const weekCells = calendarData.slice(weekStartIndex, weekStartIndex + 7);
+      const hasValidDays = weekCells.some((cell) => cell.date !== null);
+
+      if (hasValidDays) break;
+
+      lastValidIndex = weekStartIndex - 1;
+    }
+
+    return calendarData.slice(0, lastValidIndex + 1);
   }, [selectedYear, selectedMonthNum, data]);
 
   const weeklySummaries = useMemo(() => {
     const summaries: WeekSummary[] = [];
+    const totalWeeks = Math.ceil(processCalendarData.length / 7);
 
-    for (let week = 0; week < 6; week++) {
+    for (let week = 0; week < totalWeeks; week++) {
       let totalNetProfit = 0;
       let totalTrades = 0;
       let daysTraded = 0;


### PR DESCRIPTION
…pty weeks

- Increase day-profits cell sizes and font sizes for better mobile readability
- Reduce day-profits-chart YAxis width and padding on mobile
- Remove trailing empty calendar weeks when month ends mid-week
- Adjust weekly summaries to match trimmed calendar data